### PR TITLE
Fixing a Must-Statement deviation nil Pointer

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1320,7 +1320,7 @@ func (e *Entry) ApplyDeviate(deviateOpts ...DeviateOpt) []error {
 								devNodeMust[idx] = devNodeMust[len(devNodeMust)-1]            // Swap with last element
 								deviatedNode.Extra["must"] = devNodeMust[:len(devNodeMust)-1] // Trim last element
 							} else {
-								appendErr(fmt.Errorf("must statement marked for deletion not found [%s]", existingMust.Name))
+								appendErr(fmt.Errorf("must statement marked for deletion not found [%s]", mustDelete.Name))
 							}
 						}
 					}


### PR DESCRIPTION
We where referencing the wrong variable in the error string