### PR TITLE
Implement processing of refine statements, choice shorthand fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 tags
+.idea
+.DS_Store
+

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -676,6 +676,82 @@ func ToEntry(n Node) (e *Entry) {
 			e.Find(a.Name).merge(nil, a.Namespace(), a)
 		}
 
+		for _, refine := range s.Refine {
+			refineTarget := e.Find(refine.Name)
+			if refineTarget == nil {
+				return newError(s, "target node to refine %s not found in path: %s", refine.Name, e.Path())
+			}
+			// apply refinement according to https://datatracker.ietf.org/doc/html/rfc7950#section-7.13.2
+			// as best as we can
+
+			//   o  A leaf or choice node may get a default value, or a new default
+			//      value if it already had one.
+			//
+			//   o  A leaf-list node may get a set of default values, or a new set of
+			//      default values if it already had defaults; i.e., the set of
+			//      refined default values replaces the defaults already given.
+			if refine.Default != nil {
+				// TODO: do it
+				_ = refine.Default
+			}
+
+			//
+			//   o  Any node may get a specialized "description" string.
+			if refine.Description != nil {
+				refineTarget.Description = refine.Description.asString()
+			}
+
+			//
+			//   o  Any node may get a different "config" statement.
+			if refine.Reference != nil {
+				refineTarget.Config, err = tristateValue(refine.Reference)
+				if err != nil {
+					return newError(n, "error determining TriState value of Config: %s", err)
+				}
+			}
+
+			//   o  A leaf, anydata, anyxml, or choice node may get a different
+			//      "mandatory" statement.
+			if refine.Mandatory != nil {
+				refineTarget.Mandatory, err = tristateValue(refine.Mandatory)
+				if err != nil {
+					return newError(n, "error determining TriState value of Mandatory: %s", err)
+				}
+			}
+
+			//   o  A container node may get a "presence" statement.
+			// TODO(): presence statement
+
+			//   o  A leaf-list or list node may get a different "min-elements" or
+			//      "max-elements" statement.
+			if refine.MinElements != nil {
+				refineTarget.ListAttr.MinElements, err = semCheckMinElements(refine.MinElements)
+				if err != nil {
+					return newError(n, "error with refined MinElements: %s", err)
+				}
+			}
+			if refine.MaxElements != nil {
+				refineTarget.ListAttr.MaxElements, err = semCheckMaxElements(refine.MaxElements)
+				if err != nil {
+					return newError(n, "error with refined MaxElements: %s", err)
+				}
+			}
+
+			//   o  Any node may get a specialized "reference" string.
+			//   o  A leaf, leaf-list, list, container, choice, case, anydata, or
+			//      anyxml node may get additional "if-feature" expressions.
+			//   o  A leaf, leaf-list, list, container, anydata, or anyxml node may
+			//      get additional "must" expressions.
+			addExtraKeywordsToLeafEntry(refine, refineTarget)
+
+			//  o  Any node can get refined extensions, if the extension allows
+			//      refinement.  See Section 7.19 for details.
+			// TODO: should this replace or append??
+			if len(refine.Extensions) > 0 {
+				refineTarget.Exts = refine.Exts()
+			}
+		}
+
 		addExtraKeywordsToLeafEntry(n, e)
 		return e
 	}
@@ -771,6 +847,38 @@ func ToEntry(n Node) (e *Entry) {
 			}
 		case "choice":
 			for _, a := range fv.Interface().([]*Choice) {
+				cases := a.Case
+				if cases == nil || len(cases) == 0 {
+					cases = make([]*Case, 0)
+				}
+
+				for _, container := range a.Container {
+					parent := container.Parent
+					caseType := &Case{
+						Name:      container.Name,
+						Source:    nil,
+						Parent:    parent,
+						Container: []*Container{container},
+					}
+					caseType.Container[0].Parent = caseType
+					cases = append(cases, caseType)
+				}
+				a.Container = nil
+
+				for _, leaf := range a.Leaf {
+					parent := leaf.Parent
+					caseType := &Case{
+						Name:   leaf.Name,
+						Source: nil,
+						Parent: parent,
+						Leaf:   []*Leaf{leaf},
+					}
+					caseType.Leaf[0].Parent = caseType
+					cases = append(cases, caseType)
+				}
+				a.Leaf = nil
+
+				a.Case = cases
 				e.add(a.Name, ToEntry(a))
 			}
 		case "container":

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -725,10 +725,16 @@ func ToEntry(n Node) (e *Entry) {
 
 			//   o  A leaf, anydata, anyxml, or choice node may get a different
 			//      "mandatory" statement.
+
 			if refine.Mandatory != nil {
-				refineTarget.Mandatory, err = tristateValue(refine.Mandatory)
-				if err != nil {
-					return newError(n, "error determining TriState value of Mandatory: %s", err)
+				switch refineTarget.Node.(type) {
+				case *Leaf, *AnyData, *AnyXML, *Choice:
+					refineTarget.Mandatory, err = tristateValue(refine.Mandatory)
+					if err != nil {
+						return newError(n, "error determining TriState value of Mandatory: %s", err)
+					}
+				default:
+					return newError(n, "target to refine is not a leaf, anydata, anyxml, or choice: %s", refineTarget.Name)
 				}
 			}
 
@@ -738,12 +744,18 @@ func ToEntry(n Node) (e *Entry) {
 			//   o  A leaf-list or list node may get a different "min-elements" or
 			//      "max-elements" statement.
 			if refine.MinElements != nil {
+				if refineTarget.ListAttr == nil {
+					return newError(n, "target to refine is not a leaf-list or list: %s", refineTarget.Name)
+				}
 				refineTarget.ListAttr.MinElements, err = semCheckMinElements(refine.MinElements)
 				if err != nil {
 					return newError(n, "error with refined MinElements: %s", err)
 				}
 			}
 			if refine.MaxElements != nil {
+				if refineTarget.ListAttr == nil {
+					return newError(n, "target to refine is not a leaf-list or list: %s", refineTarget.Name)
+				}
 				refineTarget.ListAttr.MaxElements, err = semCheckMaxElements(refine.MaxElements)
 				if err != nil {
 					return newError(n, "error with refined MaxElements: %s", err)

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -544,6 +544,19 @@ func semCheckMinElements(v *Value) (uint64, error) {
 	return val, nil
 }
 
+func convertToCase[T Node](nodeSlicePtr *[]T, toCase func(T) *Case) []*Case {
+	orig := *nodeSlicePtr
+	out := make([]*Case, 0, len(orig))
+
+	for _, t := range orig {
+		out = append(out, toCase(t))
+	}
+
+	*nodeSlicePtr = nil
+
+	return out
+}
+
 // ToEntry expands node n into a directory Entry.  Expansion is based on the
 // YANG tags in the structure behind n.  ToEntry must only be used
 // with nodes that are directories, such as top level modules and sub-modules.
@@ -847,38 +860,90 @@ func ToEntry(n Node) (e *Entry) {
 			}
 		case "choice":
 			for _, a := range fv.Interface().([]*Choice) {
-				cases := a.Case
-				if cases == nil || len(cases) == 0 {
-					cases = make([]*Case, 0)
-				}
+				//   https://datatracker.ietf.org/doc/html/rfc7950#section-7.9.2
+				//   As a shorthand, the "case" statement can be omitted if the branch
+				//   contains a single "anydata", "anyxml", "choice", "container", "leaf",
+				//   "list", or "leaf-list" statement.  In this case, the case node still
+				//   exists in the schema tree, and its identifier is the same as the
+				//   identifier of the child node.
 
-				for _, container := range a.Container {
-					parent := container.Parent
-					caseType := &Case{
-						Name:      container.Name,
-						Source:    nil,
-						Parent:    parent,
-						Container: []*Container{container},
+				// anydata
+				a.Case = append(a.Case, convertToCase(&a.Anydata, func(c *AnyData) *Case {
+					cs := &Case{
+						Name:    c.Name,
+						Parent:  c.Parent,
+						Anydata: []*AnyData{c},
 					}
-					caseType.Container[0].Parent = caseType
-					cases = append(cases, caseType)
-				}
-				a.Container = nil
+					cs.Anydata[0].Parent = cs
+					return cs
+				})...)
 
-				for _, leaf := range a.Leaf {
-					parent := leaf.Parent
-					caseType := &Case{
-						Name:   leaf.Name,
-						Source: nil,
-						Parent: parent,
-						Leaf:   []*Leaf{leaf},
+				// anyxml
+				a.Case = append(a.Case, convertToCase(&a.Anyxml, func(c *AnyXML) *Case {
+					cs := &Case{
+						Name:   c.Name,
+						Parent: c.Parent,
+						Anyxml: []*AnyXML{c},
 					}
-					caseType.Leaf[0].Parent = caseType
-					cases = append(cases, caseType)
-				}
-				a.Leaf = nil
+					cs.Anyxml[0].Parent = cs
+					return cs
+				})...)
 
-				a.Case = cases
+				// choice
+				a.Case = append(a.Case, convertToCase(&a.Choice, func(c *Choice) *Case {
+					cs := &Case{
+						Name:   c.Name,
+						Parent: c.Parent,
+						Choice: []*Choice{c},
+					}
+					cs.Choice[0].Parent = cs
+					return cs
+				})...)
+
+				// container
+				a.Case = append(a.Case, convertToCase(&a.Container, func(c *Container) *Case {
+					cs := &Case{
+						Name:      c.Name,
+						Parent:    c.Parent,
+						Container: []*Container{c},
+					}
+					cs.Container[0].Parent = cs
+					return cs
+				})...)
+
+				// leaf
+				a.Case = append(a.Case, convertToCase(&a.Leaf, func(c *Leaf) *Case {
+					cs := &Case{
+						Name:   c.Name,
+						Parent: c.Parent,
+						Leaf:   []*Leaf{c},
+					}
+					cs.Leaf[0].Parent = cs
+					return cs
+				})...)
+
+				// list
+				a.Case = append(a.Case, convertToCase(&a.List, func(c *List) *Case {
+					cs := &Case{
+						Name:   c.Name,
+						Parent: c.Parent,
+						List:   []*List{c},
+					}
+					cs.List[0].Parent = cs
+					return cs
+				})...)
+
+				// leaf-list
+				a.Case = append(a.Case, convertToCase(&a.LeafList, func(c *LeafList) *Case {
+					cs := &Case{
+						Name:     c.Name,
+						Parent:   c.Parent,
+						LeafList: []*LeafList{c},
+					}
+					cs.LeafList[0].Parent = cs
+					return cs
+				})...)
+
 				e.add(a.Name, ToEntry(a))
 			}
 		case "container":

--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -696,18 +696,32 @@ func ToEntry(n Node) (e *Entry) {
 			}
 			// apply refinement according to https://datatracker.ietf.org/doc/html/rfc7950#section-7.13.2
 			// as best as we can
-
-			//   o  A leaf or choice node may get a default value, or a new default
-			//      value if it already had one.
 			//
 			//   o  A leaf-list node may get a set of default values, or a new set of
 			//      default values if it already had defaults; i.e., the set of
 			//      refined default values replaces the defaults already given.
-			if refine.Default != nil {
-				// TODO: do it
-				_ = refine.Default
-			}
+			//
+			//   o  A leaf or choice node may get a default value, or a new default
+			//      value if it already had one.
+			if len(refine.Defaults) != 0 {
+				switch refineTarget.Node.(type) {
+				case *Leaf, *LeafList, *Choice:
+					if refineTarget.ListAttr != nil {
+						refineTarget.Default = []string{}
+						for _, def := range refine.Defaults {
+							refineTarget.Default = append(refineTarget.Default, def.Name)
+						}
+					} else {
+						if len(refine.Defaults) > 1 {
+							return newError(refine, "only single default value allowed on leaf")
+						}
+						refineTarget.Default = []string{refine.Defaults[0].Name}
+					}
+				default:
+					return newError(refine, "refine default value only allowed on leaf, choice-node or leaf-list")
+				}
 
+			}
 			//
 			//   o  Any node may get a specialized "description" string.
 			if refine.Description != nil {
@@ -739,7 +753,13 @@ func ToEntry(n Node) (e *Entry) {
 			}
 
 			//   o  A container node may get a "presence" statement.
-			// TODO(): presence statement
+			if refine.Presence != nil {
+				if _, ok := refineTarget.Node.(*Container); !ok {
+					return newError(refine, "presence statement only allowed on container")
+				}
+				// We overwrite the current presence value and do not append
+				refineTarget.Extra["presence"] = []interface{}{&Value{Name: refine.Presence.Name}}
+			}
 
 			//   o  A leaf-list or list node may get a different "min-elements" or
 			//      "max-elements" statement.

--- a/pkg/yang/modules.go
+++ b/pkg/yang/modules.go
@@ -371,14 +371,6 @@ func (ms *Modules) Process() []error {
 		}
 	}
 
-	// rerun the error checks, after augmentation happened
-	for _, m := range ms.Modules {
-		errs = append(errs, ToEntry(m).GetErrors()...)
-	}
-	for _, m := range ms.SubModules {
-		errs = append(errs, ToEntry(m).GetErrors()...)
-	}
-
 	if len(errs) > 0 {
 		return errorSort(errs)
 	}

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -478,6 +478,7 @@ func (s *List) Groupings() []*Grouping { return s.Grouping }
 func (s *List) Typedefs() []*Typedef   { return s.Typedef }
 
 // A Choice is defined in: http://tools.ietf.org/html/rfc6020#section-7.9
+// for yang 1.1: https://datatracker.ietf.org/doc/html/rfc7950#section-7.9
 type Choice struct {
 	Name       string       `yang:"Name,nomerge"`
 	Source     *Statement   `yang:"Statement,nomerge"`
@@ -487,6 +488,7 @@ type Choice struct {
 	Anydata     []*AnyData   `yang:"anydata"`
 	Anyxml      []*AnyXML    `yang:"anyxml"`
 	Case        []*Case      `yang:"case"`
+	Choice      []*Choice    `yang:"choice"`
 	Config      *Value       `yang:"config"`
 	Container   []*Container `yang:"container"`
 	Default     *Value       `yang:"default"`

--- a/pkg/yang/yang.go
+++ b/pkg/yang/yang.go
@@ -648,7 +648,7 @@ type Refine struct {
 	Parent     Node         `yang:"Parent,nomerge"`
 	Extensions []*Statement `yang:"Ext"`
 
-	Default     *Value   `yang:"default"`
+	Defaults    []*Value `yang:"default"`
 	Description *Value   `yang:"description"`
 	IfFeature   []*Value `yang:"if-feature"`
 	Reference   *Value   `yang:"reference"`

--- a/testdata/base.yang
+++ b/testdata/base.yang
@@ -18,6 +18,8 @@ module base {
   prefix "base";
 
   include sub;
+  include refine-tests;
+  include presence-tests;
   import other {
     prefix bother;
   }

--- a/testdata/presence-tests.yang
+++ b/testdata/presence-tests.yang
@@ -1,0 +1,22 @@
+submodule presence-tests {
+  belongs-to base { prefix "sbase"; }
+
+  // sample presence
+  container presence-example-container {
+    presence "the presence of this container means something";
+  }
+
+  grouping grouping-no-presence {
+    container container-no-presence {}
+  }
+
+  container container-with-presence {
+    uses grouping-no-presence {
+        refine container-no-presence {
+            presence "this presence was added with a refine";
+        }
+    }
+  }
+
+
+}

--- a/testdata/refine-tests.yang
+++ b/testdata/refine-tests.yang
@@ -1,0 +1,48 @@
+submodule refine-tests {
+  belongs-to base { prefix "sbase"; }
+  grouping refine-sub-group {
+    leaf refine-sub-group-leaf {
+        type string;
+        default "initial-default";
+        }
+  }
+
+  // sample refine description
+  container refine-description {
+    uses refine-sub-group {
+      refine "refine-sub-group-leaf" {
+        description "new refined description";
+      }
+    }
+  }
+
+  // sample refine leaf default
+  container refine-default {
+    uses refine-sub-group {
+      refine refine-sub-group-leaf {
+        default "refined-default-string";
+      }
+    }
+  }
+
+  grouping fruit-bowl {
+    description
+      "A bowl with a few pieces of fruit by default.";
+    leaf-list fruit {
+      type string;
+      default "apple";
+      default "banana";
+    }
+  }
+
+  // sample refine leaf-list defaults
+  container exotic-bowl {
+    uses fruit-bowl {
+      refine fruit {
+        default "mango";
+        default "papaya";
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR implements the logic to process parsed refine statements according to the Yang 1.1 RFC. 
It also implements a fix for choice cases, where the case statement is not present (allowed as per RFC). It does this by inserting the case automatically, such that a choice always has a case and no shorthand is used. This is important as paths are defined as if there is always a case node in the tree, even if it is missing in the schema.